### PR TITLE
Source Code Reference

### DIFF
--- a/gems.locked
+++ b/gems.locked
@@ -33,7 +33,7 @@ DEPENDENCIES
   webrick
 
 RUBY VERSION
-   ruby 3.0.2p107
+   ruby 3.3.0p0
 
 BUNDLED WITH
    2.2.28

--- a/gems.rb
+++ b/gems.rb
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-ruby '3.0.2'
+ruby '3.3.0'
 
 gem 'htmlbeautifier'
 gem 'httparty'

--- a/src/edition.rb
+++ b/src/edition.rb
@@ -54,7 +54,7 @@ class Edition < OpenStruct
   end
 
   def self.parse(yml)
-    self.load(YAML.load(yml))
+    self.load(YAML.load(yml, permitted_classes: [Date]))
   end
 
   def self.load(edition)

--- a/src/pages/index.html.mustache
+++ b/src/pages/index.html.mustache
@@ -132,6 +132,10 @@
           <li><a href="https://www.youtube.com/@portocodes">youtube</a></li>
         </ul>
       </section>
+      <section id="source">
+        <h1>Source Code</h1>
+        
+        <p>Contribute or fork this website on <a href="https://github.com/portocodes/homepage">GitHub</a>
     </main>
   </body>
-</html>
+  </html>

--- a/src/pages/index.html.mustache
+++ b/src/pages/index.html.mustache
@@ -138,4 +138,4 @@
         <p>Contribute or fork this website on <a href="https://github.com/portocodes/homepage">GitHub</a>
     </main>
   </body>
-  </html>
+</html>

--- a/src/speaker.rb
+++ b/src/speaker.rb
@@ -20,7 +20,7 @@ def speaker(filename)
   contents = File.read(filename)
 
   cache(contents) do
-    speaker = YAML.load(contents)
+    speaker = YAML.load(contents, permitted_classes: [Date])
     speaker = [
       linkedin(speaker["linkedin"]),
       twitter(speaker["twitter"]),


### PR DESCRIPTION
Hi guys.

This change adds a simple section at the bottom to reference the source code repository for anyone interested in contributing and/or fork this project. Initially thought about a proper footer but that seemed to require a lot of work to have the style, alignment and what-not with everything else. This is a quick solution, that fits along with the rest of the project (low tech site).

# Preview

![image](https://github.com/portocodes/homepage/assets/7786556/78c0a303-6247-467d-a0ef-93293ab95917)

Feel free to let me know your thoughts. Not sure if that phrase is the best one but :D 